### PR TITLE
Updating final FR payload

### DIFF
--- a/src/gatling/resources/bodies/fr/FRSubmitApplication.json
+++ b/src/gatling/resources/bodies/fr/FRSubmitApplication.json
@@ -27,7 +27,7 @@
       "PostCode": "#{addressLines(3)}",
       "Country": "UK"
     },
-    "solicitorPhone": null,
+    "solicitorPhone": "07000000000",
     "solicitorEmail": "#{firmName}@test.com",
     "solicitorDXnumber": null,
     "solicitorAgreeToReceiveEmails": "No",


### PR DESCRIPTION
Updating final FR payload, as a solicitor's phone number is now a mandatory field